### PR TITLE
Fix TeleBot token env usage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,12 +1,16 @@
-import os 
-import telebot 
+import os
+import telebot
 
-BOT_TOKEN = os.environ.get('8073616851:AAFqfGN9G1glAs9Bm5VzBeq7kVrVlT2yhi8') 
+BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
 
-bot = telebot.TeleBot(8073616851:AAFqfGN9G1glAs9Bm5VzBeq7kVrVlT2yhi8)”
+bot = telebot.TeleBot(BOT_TOKEN)
 
-@bot.message_handler(commands=['start', 'hello']) 
-def send_welcome(message): bot.reply_to(message, "Hi there. What’s happening?")
+
+@bot.message_handler(commands=["start", "hello"])
+def send_welcome(message):
+    bot.reply_to(message, "Hi there. What's happening?")
+
 
 @bot.message_handler(func=lambda msg: True)
-def echo_all(message): bot.reply_to(message, message.text)
+def echo_all(message):
+    bot.reply_to(message, message.text)


### PR DESCRIPTION
## Summary
- sanitize `bot.py`
- read Telegram token from `TELEGRAM_BOT_TOKEN`
- initialize `TeleBot` with the env token

## Testing
- `python -m py_compile bot.py main.py`
